### PR TITLE
Remove ub in that one spot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
 [[package]]
 name = "macroassembler"
 version = "0.1.0"
+source = "git+https://github.com/playxe/masm-rs#4990414bb2c8bd6ec8668dd39c64e2206315ec90"
 dependencies = [
  "cfg-if",
  "errno",
@@ -575,6 +576,7 @@ dependencies = [
  "paste",
  "tinyvec",
  "vm-allocator",
+ "winapi",
 ]
 
 [[package]]


### PR DESCRIPTION
Used std::mem::take on some vecs to pull them out of the allocator for a moment, then do stuff, then put them back, instead of even hackier pointer UB stuff