### PR TITLE
Disassembly error message

### DIFF
--- a/src/jit/compilation.rs
+++ b/src/jit/compilation.rs
@@ -44,6 +44,7 @@ impl Compilation {
         // SAFETY:
         // `code_ref` is fully initialized
         //
+        #[cfg(feature = "disassembly")]
         unsafe {
             try_to_disassemble(
                 self.code_ref.start(),
@@ -52,6 +53,11 @@ impl Compilation {
                 &mut out,
             )
             .unwrap();
+        }
+
+        #[cfg(not(feature = "disassembly"))]
+        {
+            out.push_str("please enable the disassembly feature to show code disassembly");
         }
 
         out

--- a/src/jit/compilation.rs
+++ b/src/jit/compilation.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use macroassembler::{
-    assembler::disassembler::try_to_disassemble, wtf::executable_memory_handle::CodeRef,
-};
+use macroassembler::wtf::executable_memory_handle::CodeRef;
 
 use crate::data_section::DataSection;
 
@@ -46,7 +44,7 @@ impl Compilation {
         //
         #[cfg(feature = "disassembly")]
         unsafe {
-            try_to_disassemble(
+            macroassembler::assembler::disassembler::try_to_disassemble(
                 self.code_ref.start(),
                 self.code_ref.size_in_bytes(),
                 "  ",


### PR DESCRIPTION
Currently, if disassembly is disabled, the disassembly string is simply empty. This isn't very helpful for figuring out why it's empty, so this adds a helpful message to enable the disassembly feature.